### PR TITLE
Remove additional '=' in commons.mk

### DIFF
--- a/commons.mk
+++ b/commons.mk
@@ -1,5 +1,5 @@
 # cflags for libqap
-CFLAGS_LIB==-std=c++11 -I ../ate-pairing -I ../ate-pairing/include -I /usr/local/include
+CFLAGS_LIB=-std=c++11 -I ../ate-pairing -I ../ate-pairing/include -I /usr/local/include
 
 # cflags/ldflags for tools
 CFLAGS=-std=c++11 -I ../.. -I ../../ate-pairing/include -I /usr/local/include


### PR DESCRIPTION
Before, compiling gave the following error message on Linux 4.10.6-1-ARCH with gcc 6.3.1 20170306:
```
g++ =-std=c++11 -I ../ate-pairing -I ../ate-pairing/include -I /usr/local/include -c -o base.o base.cpp
g++: error: =-std=c++11: No such file or directory
```